### PR TITLE
re-loads component if `left` and `right` component props change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default class AsyncBranch extends React.Component {
  } 
 
  componentWillReceiveProps(nextProps) {
-  if (nextProps.condition !== this.props.condition) {
+  if ((nextProps.condition !== this.props.condition) || (nextProps.left !== this.props.left) || (nextProps.right !== this.props.right)) {
    this.loadComponent(nextProps);
   }
  }


### PR DESCRIPTION
thanks again for this very useful component!

I ran into a case where it would not fetch the component if i changed the component for the `left` or `right` branch on subsequent renders